### PR TITLE
Use direct Maven download url to avoid wget filename borking

### DIFF
--- a/jquery-maven-artifact.js
+++ b/jquery-maven-artifact.js
@@ -2,7 +2,7 @@
   function downloadUrl(groupId, artifactId, version, type) {
     var groupPath = groupId.replace('.', '/');
     var artifactPath = artifactId.replace('.', '/');
-    return 'http://search.maven.org/remotecontent?filepath=' + groupPath + '/' + artifactPath + '/' + version + '/' + artifactId + '-' + version + type;
+    return 'http://repo1.maven.org/maven2/' + groupPath + '/' + artifactPath + '/' + version + '/' + artifactId + '-' + version + type;
   }
 
   $.fn.artifactVersion = function(groupId, artifactId, callback) {


### PR DESCRIPTION
For those few occasions where you need to download something using wget, it's nice if the url doesn't include a query string - because wget will perform a horrific tapdance of destruction on the filename. For instance this download:

$ wget http://search.maven.org/remotecontent?filepath=com/squareup/otto/1.3.2/otto-1.3.2.jar

...gives this awful filename which is to be avoided:

"remotecontent?filepath=com%2Fsquareup%2Fotto%2F1.3.2%2Fotto-1.3.2.jar"

The repo1.maven.org domain is sewn into a million Maven clients around the world so it's unlikely to change.

Very pleased to see you've dressed my search.maven.org Solr technique up into a JQuery plugin by the way :)
